### PR TITLE
Fix bad filename reference for crosshair font file

### DIFF
--- a/resource/clientscheme.res
+++ b/resource/clientscheme.res
@@ -6363,7 +6363,7 @@ Scheme
 		}
 		"9"
 		{
-			"font" "resource/Crosshairs.otf"
+			"font" "resource/crosshairs.ttf"
 			"name" "Crosshairs Regular"
 		}
 		"10"


### PR DESCRIPTION
In original OMPhud, the crosshair font was named `Crosshairs.otf`. In this fork, it's now named `Crosshairs.ttf`. But the reference in `clientscheme.res` was never updated to reflect that change, so the font-based crosshairs weren't working.

This pull request updates the filename reference so it points to the correct file name.
